### PR TITLE
Update hello_world.libraries.yml

### DIFF
--- a/hello_world/hello_world.libraries.yml
+++ b/hello_world/hello_world.libraries.yml
@@ -5,3 +5,5 @@ hello-world:
       css/hello_world.css: {}
   js:
     js/hello_world.js: {}
+  dependencies:
+    - core/jquery.ui.draggable


### PR DESCRIPTION
The core dependency needs to be declared before the JS will fire properly. The specific jQuery needs to be called as it will not call sub-libraries (ex: declaring "- core/jquery.ui" as a dependency will NOT call our jquery.ui.draggable that we need.
